### PR TITLE
Add curl-dev along with curl

### DIFF
--- a/template/go-opencv/Dockerfile
+++ b/template/go-opencv/Dockerfile
@@ -1,11 +1,11 @@
 FROM nicholasjackson/go-opencv:1.9.1
 
 # Add the watchdog
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl curl-dev \
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -g https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
-    && apk del curl --no-cache
+    && apk del curl curl-dev --no-cache
 
 WORKDIR /go/src/handler
 COPY . .


### PR DESCRIPTION
Fixes Issue: https://github.com/nicholasjackson/open-faas-functions/issues/1

Without curl dev `alpine` curl package cause the below issue 
```bash
curl: (48) An unknown option was passed in to libcurl
```
Installing `curl-dev` fixes it

Origin thread: https://stackoverflow.com/questions/11678085/curl-48-an-unknown-option-was-passed-in-to-libcurl


Signed-off-by: Swarvanu Sengupta <swarvanusg@gmail.com>